### PR TITLE
Add support for STS ExternalId parameter

### DIFF
--- a/Python/aws_recipes_assume_role.py
+++ b/Python/aws_recipes_assume_role.py
@@ -21,7 +21,7 @@ def main(args):
 
     # Assume role and store credentials
     try:
-        assume_role_and_save_in_credentials(args.profile[0], args.role_arn[0], args.role_session_name[0], args.mfa_serial[0], args.mfa_code[0])
+        assume_role_and_save_in_credentials(args.profile[0], args.role_arn[0], args.role_session_name[0], args.mfa_serial[0], args.mfa_code[0], args.external_id[0])
     except Exception as e:
         printException(e)
         return 42
@@ -33,6 +33,7 @@ def main(args):
 
 add_sts_argument(parser, 'mfa-serial')
 add_sts_argument(parser, 'mfa-code')
+add_sts_argument(parser, 'external-id')
 
 parser.add_argument('--role-arn',
                     dest='role_arn',


### PR DESCRIPTION
Adds support for ExternalID parameter, required when calling AssumeRole for cross-account access with ExternalID (essentially an opaque shared secret) specified in the destination account's policy.